### PR TITLE
Allow file lookup to be used to read manifest files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Role Variables
 * `kube_resource_wait` - whether to wait for resources to reach their desired state (default `no`)
 * `kube_resource_wait_timeout` - how long to wait in seconds for resources if `kube_resource_wait` is on
   (default 120)
+* `kube_resource_lookup_plugin` - The lookup plugin to use when reading manifests. If you're reading pure
+  kubernetes manifests, you can use `file` which helps if those manifests contain jinja. Defaults to
+  `template`
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ kube_resource_wait_timeout: 120
 kube_resource_set_owner: false
 kube_resource_prefix_label: kube_resource_prefix
 kube_resource_deployments_api: apps/v1
+kube_resource_lookup_plugin: template

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,14 +13,14 @@
 - name: create secrets list
   set_fact:
     kube_resource_secrets_from_files: >
-      {{ kube_resource_secrets_from_files + lookup('template', item)|from_yaml_all|list }}
+      {{ kube_resource_secrets_from_files + lookup(kube_resource_lookup_plugin, item)|from_yaml_all|list }}
   loop: "{{ kube_resource_secrets_files }}"
   no_log: "{{ not kube_resource_UNSAFE_show_logs }}"
 
 - name: create manifests list
   set_fact:
     kube_resource_manifests_from_files: >
-      {{ kube_resource_manifests_from_files + lookup('template', item)|from_yaml_all|list }}
+      {{ kube_resource_manifests_from_files + lookup(kube_resource_lookup_plugin, item)|from_yaml_all|list }}
   loop: "{{ kube_resource_manifest_files }}"
 
 - name: create configmaps


### PR DESCRIPTION
Useful if no ansible templating of the manifest files
is required, especially if those manifests contain
jinja themselves